### PR TITLE
Quick Start Notebook looking for invalid file for ESMFold prediction

### DIFF
--- a/notebooks/quick-start-protein-folding.ipynb
+++ b/notebooks/quick-start-protein-folding.ipynb
@@ -488,7 +488,7 @@
     "target.download_predictions(local_path=\"data\", job=last_job_name)\n",
     "\n",
     "print(f\"Displaying predicted structure for job {last_job_name}\")\n",
-    "pdb = f\"data/{target_id}/predictions/{last_job_name}/{target_id}.pdb\"\n",
+    "pdb = f\"data/{target_id}/predictions/{last_job_name}/prediction.pdb\"\n",
     "utils.plot_banded_pdb(pdb)\n",
     "utils.plot_metrics(pdb)"
    ]


### PR DESCRIPTION

When running the "Plot ESMFold prediction" in the quick-start-protein-folding.ipynb notebook, it would fail because of it being unable to find a file called 7FCC.pdb (aka {target_id}.pdb).

Output for the ESMFold code found at infrastructure/docker/esmfold/esm/scripts/esmfold_inference.py on line 199 is a file called prediction.pdb. The Quick-Start Notebook is looking for pdb = f"data/{target_id}/predictions/{last_job_name}/{target_id}.pdb" for the plot data, which is not a valid file.  Notebook should be changed to reflect the file being output by the code.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
