### PR TITLE
 Use BuildSpec with wait response for download container 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.13.1] - 2025-05-28
+
+### 1.13.1 Fixed
+
+- Fix issue with Download container build timing out
+
+---
+
 ## [1.13.0] - 2025-03-14
 
 ### 1.13.0 Update

--- a/infrastructure/cloudformation/batch-protein-folding-cfn-container.yaml
+++ b/infrastructure/cloudformation/batch-protein-folding-cfn-container.yaml
@@ -373,7 +373,8 @@ Resources:
       ResourceAccessRole: !GetAtt CodeBuildRole.Arn
       ServiceRole: !GetAtt CodeBuildRole.Arn
       Source:
-        BuildSpec: infrastructure/docker/buildspec.yaml
+        # BuildSpec: infrastructure/docker/buildspec.yaml
+        BuildSpec: infrastructure/docker/download/buildspec_with_wait.yaml
         Location: !Sub "${CodeRepoS3BucketName}/main/batch-protein-folding.zip"
         Type: S3
       Tags:


### PR DESCRIPTION
*Issue #, if available:*
#41 
*Description of changes:*.

[Use BuildSpec with wait response for download container](https://github.com/aws-solutions-library-samples/aws-batch-arch-for-protein-folding/commit/974e7f1d9861639269c6abbc7e4b38cec5d41b4c)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
